### PR TITLE
Remove erroneous intro copy from index pages

### DIFF
--- a/app/views/v1-1/index.html
+++ b/app/views/v1-1/index.html
@@ -13,15 +13,6 @@
 					HTML Prototypes V1.1
 				</h1>
 
-				<h2 class="heading-large">Introduction</h2>
-				<div class="text">
-					<p>This is a place where we iterate wildly.</p>
-
-					<p>This page acts as an index to the various prototypes and ideas we’re having.</p>
-
-					<p>Full history resides in github repo, and not here as 'older' or previous versions</p>
-				</div>
-
 				<h3 class="heading-medium">Lender creates a case</h3>
 				<ul>
 					<li><strong>1.</strong> <a href="/v1-1/step1/step-1-login">Lender creates a Case</a></li>

--- a/app/views/v1-2/index.html
+++ b/app/views/v1-2/index.html
@@ -13,15 +13,6 @@
 					HTML Prototypes V1.2
 				</h1>
 
-				<h2 class="heading-large">Introduction</h2>
-				<div class="text">
-					<p>This is a place where we iterate wildly.</p>
-
-					<p>This page acts as an index to the various prototypes and ideas we’re having.</p>
-
-					<p>Full history resides in github repo, and not here as 'older' or previous versions</p>
-				</div>
-
 				<h3 class="heading-medium">Create a case</h3>
 				<ul>
 					<li><strong>1.</strong> <a href="/v1-2/step1/step-1-login">Create a Case</a></li>

--- a/app/views/v1/index.html
+++ b/app/views/v1/index.html
@@ -13,15 +13,6 @@
 					HTML Prototypes
 				</h1>
 
-				<h2 class="heading-large">Introduction</h2>
-				<div class="text">
-					<p>This is a place where we iterate wildly.</p>
-
-					<p>This page acts as an index to the various prototypes and ideas we’re having.</p>
-
-					<p>Full history resides in github repo, and not here as 'older' or previous versions</p>
-				</div>
-
 				<h3 class="heading-medium">Lender creates a case</h3>
 				<ul>
 					<li><strong>1.</strong> <a href="/v1/step1/step-1-login">Lender creates case</a></li>


### PR DESCRIPTION
Simply removing the text intro from the version index pages. Basically because it's not needed, and wasn't accurate anyway.
