### PR TITLE
Update "confirm mortgage details screen"

### DIFF
--- a/app/views/v1-2/step3/step-5-mortgage-summary.html
+++ b/app/views/v1-2/step3/step-5-mortgage-summary.html
@@ -56,7 +56,7 @@
       <div class="grid-row">
         <div class="column-half">
           <dl class="definition-tabular--1-2">
-            <dt>Address</dt>
+            <dt>Correspondance address</dt>
             <dd>
               Flat 16 Kingman Court<br>
               Verdant Road<br>
@@ -91,7 +91,7 @@
 
       <div class="grid-row" style="margin-bottom:10px;">
         <div class="column-quarter">
-          Addresses:
+          Correspondance addresses:
         </div>
         <div class="column-quarter" style="padding-left:0px">
           Flat 16 Kingman Court<br>

--- a/app/views/v1-2/step3/step-5-mortgage-summary.html
+++ b/app/views/v1-2/step3/step-5-mortgage-summary.html
@@ -1,8 +1,10 @@
-{{<layout-v1-2}}
+{{<govuk_template}}
 
-{{$pageTitle}}
-	GOV.UK prototyping kit
-{{/pageTitle}}
+{{$head}}
+  {{>includes/head}}
+  <link rel="stylesheet" type="text/css" href="/public/stylesheets/alphagov-static.css">
+  <link rel="stylesheet" type="text/css" href="/public/stylesheets/case-system-v1-2.css">
+{{/head}}
 
 {{$content}}
 
@@ -11,277 +13,146 @@
 
     {{>includes/alpha_banner}}
 
-    <h1 class="heading-large">Confirm Mortgage details</h1>
-    <p class="lede text">Please check all the details carefully before confirming.</p>
-
-
-		<article class="legal-document--bounds">
-
-			<section class="document-section document-section--bordered">
-		    <h2 class="heading-medium">Date</h2>
-		    <div class="grid-wrapper document-section__item">
-		      <div class="grid grid-1-4">
-		        <p class="inner-block">Date</p>
-		      </div>
-		      <div class="grid grid-1-4">
-		        <div class="inner-block"></div>
-		      </div>
-		    </div>
-		  </section>
-
-		  <section class="document-section">
-    		<h2 class="heading-medium document-section__heading">Property</h2>
-    		<div class="grid-wrapper document-section__item">
-		      <div class="grid grid-1-4">
-		        <div class="inner-block">Address</div>
-		      </div>
-		      <div class="grid grid-1-3">
-		        <div class="inner-block">
-		          <p itemscope itemtype="http://schema.org/PostalAddress" class="addr-collapse">
-		    				<span itemprop="streetAddress">
-			    				Flat 16 Kingman Court<br>
-			    				Verdant Road<br>
-		    				</span>
-		    				<span itemprop="addressLocality">London</span><br>
-		    				<span itemprop="postalCode">SV19 9BT</span>
-		    			</p>
-		        </div>
-		      </div>
-    		</div>
-
-		    <div class="grid-wrapper document-section__item">
-		      <div class="grid grid-1-4">
-		        <div class="inner-block">Title</div>
-		      </div>
-		      <div class="grid grid-1-3">
-		        <div class="inner-block">GHR67832</div>
-		      </div>
-		    </div>
-
-		  </section><!--  end property section -->
-
-		  <section class="document-section document-section--bordered">
-		  	<h2 class="heading-medium">Borrowers </h2>
-
-			  <div class="grid-wrapper document-section__item">
-			    <div class="grid grid-1-4">
-			      <p class="inner-block">No. of borrowers</p>
-			    </div>
-			    <div class="grid grid-1-4">
-			      <div class="inner-block">2</div>
-			    </div>
-			  </div>
-
-
-
-	<div class="grid-wrapper document-section__item">
-    <div class="grid">
-      <p class="inner-block"><b>Borrower 1</b></p>
-    </div>
-  </div>
-  <div class="grid-wrapper document-section__item">
-    <div class="grid grid-1-4">
-      <div class="inner-block">Name</div>
-    </div>
-    <div class="grid grid-1-4">
-      <p class="inner-block">Sarah Jane Spencer</p>
-    </div>
-  </div>
-
-  <div class="grid-wrapper document-section__item ">
-    <div class="grid grid-1-4">
-      <div class="inner-block">Address(es)</div>
+    <div class="text">
+      <h1 class="heading-large">Confirm Mortgage details</h1>
+      <p class="lede text">Please check all the details carefully before confirming.</p>
     </div>
 
-    <div class="grid grid-1-4">
-      <div class="inner-block">
-	      <p itemscope itemtype="http://schema.org/PostalAddress" class="addr-collapse">
-	    		<span itemprop="streetAddress">Flat 16 Kingman Court<br></span>
-	    		<span itemprop="addressLocality">Verdant Road</span><br>
-	    		<span itemprop="">London</span><br>
-	    		<span itemprop="postalCode">SV19 9BT</span>
-	    	</p>
-     	</div>
+    <div class="legal-division--top">
 
-      <div class="inner-block">
-        <a href="#" class="button-secondary">Change<span class="visuallyhidden"> address details</span></a>
-      </div>
-    </div>
+      <dl class="definition-inline">
+        <dt><b>Date</b></dt>
+        <dd class="missing-info-placeholder">Not yet dated</dd>
+      </dl>
 
-    <div class="grid grid-1-4">
-      <div class="inner-block">
-        <a href="#" class="button-secondary">Add<span class="visuallyhidden"> another</span> address</a>
-      </div>
-    </div>
+      <h2 class="heading-large division--top">Property</h2>
+      <p itemscope itemtype="http://schema.org/PostalAddress">
+        <span itemprop="streetAddress">
+          Flat 16 Kingman Court<br>
+          Verdant Road<br>
+        </span>
+        <span itemprop="addressLocality">London</span><br>
+        <span itemprop="postalCode">SV19 9BT</span>
+      </p>
 
-  </div>
+      <dl class="definition-inline">
+        <dt>Title number</dt>
+        <dd>GHR67832</dd>
+      </dl>
 
-  <div class="grid-wrapper document-section__item">
-    <div class="grid grid-1-4">
-      <div class="inner-block">Email</div>
-    </div>
+      <h2 class="heading-large division--top">Borrowers</h2>
 
-    <div class="grid grid-1-4">
-      <p class="inner-block">sarah@anemailaddress.co.uk</p>
-    </div>
+      <h3 class="heading-medium collapse-top">Borrower 1 <a href="#" class="font-xsmall">Edit details</a></h3>
 
-    <div class="grid grid-1-4">
-      <div class="inner-block">
-        <a href="#" class="button-secondary">Change<span class="visuallyhidden"> email address</span></a>
-      </div>
-    </div>
-  </div>
-
-
-  <div class="grid-wrapper document-section__item">
-    <div class="grid">
-      <p class="inner-block"><b>Borrower 2</b></p>
-    </div>
-  </div>
-  <div class="grid-wrapper document-section__item">
-    <div class="grid grid-1-4">
-      <div class="inner-block">Name</div>
-    </div>
-    <div class="grid grid-1-4">
-      <p class="inner-block">Peter Smith</p>
-    </div>
-  </div>
-
-  <div class="grid-wrapper document-section__item ">
-    <div class="grid grid-1-4">
-      <div class="inner-block">Address(es)</div>
-    </div>
-
-    <div class="grid grid-1-4">
-      <div class="inner-block">
-        <p itemscope itemtype="http://schema.org/PostalAddress" class="addr-collapse">
-    <span itemprop="streetAddress">Flat 16 Kingman Court<br>
-
-    </span>
-    <span itemprop="addressLocality">Verdant Road</span><br>
-
-    <span itemprop="">London</span><br>
-
-    <span itemprop="postalCode">SV19 9BT</span>
-  </p>
+      <div class="grid-row">
+        <div class="column-half">
+          <dl class="definition-tabular--1-2--b">
+            <dt>Name</dt>
+            <dd>Sarah Jane Spencer</dd>
+          </dl>
+        </div>
       </div>
 
-      <div class="inner-block">
-        <a href="#" class="button-secondary">Change<span class="visuallyhidden"> address details</span></a>
+      <div class="grid-row">
+        <div class="column-half">
+          <dl class="definition-tabular--1-2">
+            <dt>Address</dt>
+            <dd>
+              Flat 16 Kingman Court<br>
+              Verdant Road<br>
+              London<br>
+              SV19 9BT
+            </dd>
+          </dl>
+        </div>
       </div>
 
-    </div>
-
-    <div class="grid grid-1-4">
-      <div class="inner-block">
-        <p itemscope itemtype="http://schema.org/PostalAddress" class="addr-collapse">
-    <span itemprop="streetAddress">12 Spring Road<br>
-
-    </span>
-    <span itemprop="addressLocality">Wakefield</span><br>
-
-    <span itemprop="">Yorks</span><br>
-
-    <span itemprop="postalCode">WK12 9AB</span>
-  </p>
+      <div class="grid-row">
+        <div class="column-half">
+          <dl class="definition-tabular--1-2">
+            <dt>Email</dt>
+            <dd>sarah@anemailaddress.co.uk</dd>
+            <dt>Mobile phone number</dt>
+            <dd>07964 123 321</dd>
+          </dl>
+        </div>
       </div>
 
-      <div class="inner-block">
-        <a href="#" class="button-secondary">Change<span class="visuallyhidden"> address details</span></a>
+      <h3 class="heading-medium">Borrower 2 <a href="#" class="font-xsmall">Edit details</a></h3>
+
+      <div class="grid-row">
+        <div class="column-half">
+          <dl class="definition-tabular--1-2--b">
+            <dt>Name</dt>
+            <dd>Peter Smith</dd>
+          </dl>
+        </div>
       </div>
 
-    </div>
+      <div class="grid-row" style="margin-bottom:10px;">
+        <div class="column-quarter">
+          Addresses:
+        </div>
+        <div class="column-quarter" style="padding-left:0px">
+          Flat 16 Kingman Court<br>
+          Verdant Road<br>
+          London<br>
+          SV19 9BT
+        </div>
+        <div class="column-quarter" style="padding-left:0px">
+          12 Spring Road<br>
+          Wakefield<br>
+          Yorks<br>
+          WK12 9AB
+        </div>
+      </div>
 
-
-
-      <div class="grid grid-1-4">
-        <div class="inner-block">
-          <a href="#" class="button-secondary">Add<span class="visuallyhidden"> another</span> address</a>
+      <div class="grid-row">
+        <div class="column-half">
+          <dl class="definition-tabular--1-2">
+            <dt>Email</dt>
+            <dd>peter.smith@anemailaddress.co.uk</dd>
+            <dt>Mobile phone number</dt>
+            <dd>07964 123 321</dd>
+          </dl>
         </div>
       </div>
 
 
-  </div>
+      <h2 class="heading-large division--top">Mortgage details</h2>
 
-  <div class="grid-wrapper document-section__item">
-    <div class="grid grid-1-4">
-      <div class="inner-block">Email</div>
-    </div>
-
-    <div class="grid grid-1-4">
-      <p class="inner-block">p.smithy@aol.com</p>
-    </div>
-
-      <div class="grid grid-1-4">
-        <div class="inner-block">
-          <a href="#" class="button-secondary">Change<span class="visuallyhidden"> email address</span></a>
+      <div class="grid-row">
+        <div class="column-half">
+          <dl class="definition-tabular--1-2">
+            <dt>MD reference</dt>
+            <dd><b>MD1234F</b> <a href="#" class="font-xsmall">Change</a></dd>
+            <dt>Lender</dt>
+            <dd>Nationwide</dd>
+          </dl>
         </div>
       </div>
 
-
-  </div>
-
-
-</section><!-- end buyers section -->
-
-
-
-
-  <section class="document-section document-section--bordered">
-    <h2 class="heading-medium">Mortgage details</h2>
-
-    <div class="grid-wrapper document-section__item ">
-      <div class="grid grid-1-4">
-        <div class="inner-block">MD Reference</div>
-      </div>
-      <div class="grid grid-1-4">
-        <div class="inner-block">MD1234F</div>
-      </div>
-
-      <div class="grid grid-1-4">
-        <div class="inner-block">
-          <a href="mortgage-details" class="button-secondary">Change<span class="visuallyhidden"> MD reference number</span></a>
+      <div class="grid-row">
+        <div class="column-half">
+          <dl class="definition-tabular--1-2">
+            <dt>Address</dt>
+            <dd>
+              Nationwide Building Society<br>
+              Nationwide House<br>
+              Pipers Way<br>
+              Swindon<br>
+              SN38 1NW
+            </dd>
+          </dl>
         </div>
       </div>
 
     </div>
 
-    <div class="grid-wrapper document-section__item ">
-      <div class="grid grid-1-4">
-        <div class="inner-block">Lender</div>
-      </div>
-      <div class="grid grid-1-4">
-        <div class="inner-block">Nationwide</div>
-      </div>
-    </div>
-
-    <div class="grid-wrapper document-section__item ">
-      <div class="grid grid-1-4">
-        <div class="inner-block">Lender address</div>
-      </div>
-      <div class="grid grid-1-4">
-        <div class="inner-block">
-          <p itemscope itemtype="http://schema.org/PostalAddress" class="addr-collapse">
-    <span itemprop="streetAddress">Nationwide Building Society Nationwide House<br>
-
-      Pipers Way<br>
-
-    </span>
-    <span itemprop="addressLocality">Swindon</span><br>
-
-    <span itemprop="postalCode">SN38 1NW</span>
-  </p>
-        </div>
-      </div>
-    </div>
 
 
-  </section><!-- end mortgage section -->
 
-
-</article>
-
-    <form action="step-6-mortgage-deed" method="get" class="form">
+    <form action="step-6-mortgage-deed" method="get" class="form legal-division--top">
       <div class="form-group">
         <label for="check-1" class="block-label">
           <input id="check-1" type="checkbox" name="agree-execution">
@@ -298,4 +169,4 @@
 
 {{/content}}
 
-{{/layout-v1-2}}
+{{/govuk_template}}

--- a/app/views/v1-2/step3/step-5-mortgage-summary.html
+++ b/app/views/v1-2/step3/step-5-mortgage-summary.html
@@ -56,7 +56,7 @@
       <div class="grid-row">
         <div class="column-half">
           <dl class="definition-tabular--1-2">
-            <dt>Correspondance address</dt>
+            <dt>Correspondance address(es)</dt>
             <dd>
               Flat 16 Kingman Court<br>
               Verdant Road<br>
@@ -91,7 +91,7 @@
 
       <div class="grid-row" style="margin-bottom:10px;">
         <div class="column-quarter">
-          Correspondance addresses:
+          Correspondance address(es):
         </div>
         <div class="column-quarter" style="padding-left:0px">
           Flat 16 Kingman Court<br>


### PR DESCRIPTION
Cleaning up the layout of /v1-2/step3/step-5-mortgage-summary

Differences are:
• "Edit details" links alongside each borrower, _not_ multiple controls
• All known contact details included - in the example it means we've added mobiles - is this correct?

Before:

![1](https://cloud.githubusercontent.com/assets/1913757/7135374/01a528ce-e29e-11e4-927c-a6b0254ef950.png)

After:

![2](https://cloud.githubusercontent.com/assets/1913757/7135379/0bb54074-e29e-11e4-976d-b85d8b3c8d81.png)
